### PR TITLE
Receiver Handling, Scan Delegator Discovery & Display

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
          * versionCode is calculated as: major * 10000 + minor * 100 + patch
          * versionName is "major.minor.patch"
          */
-        val versionMajor = 2
-        val versionMinor = 3
+        val versionMajor = 3
+        val versionMinor = 0
         val versionPatch = 0
 
         versionCode = (versionMajor * 10000) + (versionMinor * 100) + versionPatch
@@ -109,6 +109,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.navigation.runtime.android)
     implementation(libs.androidx.ui.text)
+    implementation(libs.androidx.room.ktx)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="31" />
 
-    <!-- Camera permission required for QR code scanning -->
-    <uses-permission android:name="android.permission.CAMERA" />
-
     <!-- Location permissions required for BLE scanning on older Android versions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/java/com/android/broadcastassistant/audio/BassGattManager.kt
+++ b/app/src/main/java/com/android/broadcastassistant/audio/BassGattManager.kt
@@ -8,34 +8,31 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.android.broadcastassistant.data.BassCommand
+import com.android.broadcastassistant.delegator.BassBroadcastStateParser
 import com.android.broadcastassistant.util.*
 import kotlinx.coroutines.*
-import java.util.*
+import java.util.UUID
 import kotlin.coroutines.*
 
 /**
  * Manager for Broadcast Audio Scan Service (BASS) GATT interactions.
- *
- * Responsibilities:
- * - Connect to Scan Delegator devices via GATT.
- * - Discover BASS service and Control Point characteristic.
- * - Send BASS Control Point commands via [BassCommand].
- * - Handle multiple simultaneous connections and safe disconnection.
- *
- * Logs all key steps, warnings, and errors using the centralized logging utility.
+ * Handles connections to Scan Delegator devices, sending Control Point commands,
+ * reading Broadcast Receive State (BRS), and managing multiple simultaneous connections.
  */
 class BassGattManager(private val context: Context) {
 
     companion object {
-        private val BASS_SERVICE_UUID: UUID = UuidUtils.BASS_SERVICE_UUID
-        private val BASS_CONTROL_POINT_UUID: UUID = UuidUtils.BASS_CONTROL_POINT_UUID
+        private val BASS_SERVICE_UUID: UUID = UuidUtils.BASS_SERVICE_UUID // BASS service UUID
+        private val BASS_CONTROL_POINT_UUID: UUID = UuidUtils.BASS_CONTROL_POINT_UUID // Control Point UUID
+        private val BASS_BRS_UUID: UUID = UuidUtils.BASS_BROADCAST_RECEIVE_STATE_UUID // Broadcast Receive State UUID
     }
 
-    /** Store multiple connections keyed by device address */
-    private val bluetoothGatt = mutableMapOf<String, BluetoothGatt>()
+    private val bluetoothGatt = mutableMapOf<String, BluetoothGatt>() // Active GATT connections keyed by device address
+    private val gattCallbacks = mutableMapOf<String, BluetoothGattCallback>() // Store callbacks per device
 
     /**
-     * Sends a BASS Control Point command to a device with retry logic.
+     * Sends a BASS Control Point command to a device.
+     * Handles GATT connection, service discovery, retries, and optional auto-disconnect.
      */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     suspend fun sendControlPoint(command: BassCommand) {
@@ -46,7 +43,7 @@ class BassGattManager(private val context: Context) {
             val device: BluetoothDevice? = try {
                 adapter?.getRemoteDevice(command.deviceAddress)
             } catch (e: IllegalArgumentException) {
-                loge("Invalid device address ${command.deviceAddress}", e)
+                loge("Invalid device address: ${command.deviceAddress}", e)
                 null
             }
 
@@ -60,7 +57,7 @@ class BassGattManager(private val context: Context) {
                 return
             }
 
-            // Reuse existing GATT connection if available, else connect
+            // Use existing GATT or connect if not present
             val gatt = bluetoothGatt[command.deviceAddress] ?: connectGattSuspend(device).also {
                 bluetoothGatt[command.deviceAddress] = it
             }
@@ -79,7 +76,7 @@ class BassGattManager(private val context: Context) {
                 return
             }
 
-            // Retry up to 2 times
+            // Retry write up to 2 times
             repeat(2) { attempt ->
                 try {
                     writeCharacteristicSuspend(gatt, controlPointChar, command.controlPointData)
@@ -91,7 +88,6 @@ class BassGattManager(private val context: Context) {
             }
 
             loge("All retries failed for ${command.deviceAddress}")
-
             if (command.autoDisconnect) disconnect(command.deviceAddress)
 
         } catch (e: Exception) {
@@ -100,10 +96,103 @@ class BassGattManager(private val context: Context) {
         }
     }
 
+    /**
+     * Reads the Broadcast Receive State (BRS) from a connected device.
+     * Returns a list of [com.android.broadcastassistant.delegator.BassBroadcastStateParser.BassSourceInfo] or empty list on failure.
+     */
+    @ExperimentalCoroutinesApi
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    suspend fun readBroadcastReceiveState(deviceAddress: String): List<BassBroadcastStateParser.BassSourceInfo> {
+        val gatt = bluetoothGatt[deviceAddress]
+            ?: throw IllegalStateException("No GATT connection for $deviceAddress")
+
+        val service = gatt.getService(BASS_SERVICE_UUID)
+            ?: throw IllegalStateException("BASS service not found on $deviceAddress")
+
+        val stateChar = service.getCharacteristic(BASS_BRS_UUID)
+            ?: throw IllegalStateException("Broadcast Receive State characteristic not found")
+
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            loge("BLUETOOTH_CONNECT permission not granted")
+            return emptyList()
+        }
+
+        return suspendCancellableCoroutine { cont ->
+            try {
+                // Temporary callback for this read operation
+                val callback = object : BluetoothGattCallback() {
+                    override fun onCharacteristicRead(
+                        gatt: BluetoothGatt,
+                        characteristic: BluetoothGattCharacteristic,
+                        status: Int
+                    ) {
+                        if (characteristic.uuid == BASS_BRS_UUID) {
+                            if (status == BluetoothGatt.GATT_SUCCESS) {
+                                @Suppress("DEPRECATION") val value = characteristic.value ?: byteArrayOf()
+                                val sources = BassBroadcastStateParser.parse(value) // Parse BRS
+                                cont.resume(sources) {}
+                                logi("BRS read succeeded for ${gatt.device.address}")
+                            } else {
+                                logw("Failed to read BRS, status=$status")
+                                cont.resume(emptyList()) {}
+                            }
+                        }
+                    }
+                }
+
+                // Store callback for this device
+                gattCallbacks[deviceAddress] = callback
+
+                // Initiate characteristic read
+                if (!gatt.readCharacteristic(stateChar)) {
+                    loge("readCharacteristic initiation failed for $deviceAddress")
+                    cont.resume(emptyList()) {}
+                }
+
+                // Ensure coroutine cancellation cleans up if needed
+                cont.invokeOnCancellation {
+                    try { disconnect(deviceAddress) } catch (_: Exception) {}
+                }
+
+            } catch (e: Exception) {
+                loge("Failed to read Broadcast Receive State", e)
+                cont.resume(emptyList()) {}
+            }
+        }
+    }
+
+    /** Disconnects and cleans up a single device's GATT connection */
+    fun disconnect(deviceAddress: String) {
+        bluetoothGatt[deviceAddress]?.let { gatt ->
+            try {
+                if (ContextCompat.checkSelfPermission(context,
+                        Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+                    gatt.close() // Close GATT safely
+                    logi("Closed GATT connection for $deviceAddress")
+                } else {
+                    logw("BLUETOOTH_CONNECT permission not granted; skipping close() for $deviceAddress")
+                }
+            } catch (se: SecurityException) {
+                loge("SecurityException on bluetoothGatt.close() for $deviceAddress", se)
+            } finally {
+                bluetoothGatt.remove(deviceAddress) // Remove from map
+                gattCallbacks.remove(deviceAddress) // Remove callback
+            }
+        }
+    }
+
+    /** Disconnects all active GATT connections */
+    fun disconnectAll() {
+        val addresses = bluetoothGatt.keys.toList() // Copy keys to avoid concurrent modification
+        addresses.forEach { disconnect(it) }
+    }
+
+    /** Suspended GATT connection with service discovery */
     private suspend fun connectGattSuspend(device: BluetoothDevice): BluetoothGatt =
         suspendCancellableCoroutine { cont ->
             val callback = object : BluetoothGattCallback() {
-
                 override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                     try {
                         if (status != BluetoothGatt.GATT_SUCCESS) {
@@ -114,7 +203,6 @@ class BassGattManager(private val context: Context) {
 
                         if (newState == BluetoothGatt.STATE_CONNECTED) {
                             logi("Connected to ${gatt.device.address}")
-
                             if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
                                 try {
                                     logd("Discovering services on ${gatt.device.address}")
@@ -161,6 +249,7 @@ class BassGattManager(private val context: Context) {
             }
         }
 
+    /** Suspended characteristic write with logging and exception handling */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private suspend fun writeCharacteristicSuspend(
         gatt: BluetoothGatt,
@@ -180,33 +269,5 @@ class BassGattManager(private val context: Context) {
             loge("Unexpected error during write", e)
             cont.resumeWithException(e)
         }
-    }
-
-    /**
-     * Disconnect and cleanup a specific device GATT connection.
-     */
-    fun disconnect(deviceAddress: String) {
-        bluetoothGatt[deviceAddress]?.let { gatt ->
-            try {
-                if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
-                    gatt.close()
-                    logi("Closed GATT connection for $deviceAddress")
-                } else {
-                    logw("BLUETOOTH_CONNECT permission not granted, skipping close() for $deviceAddress")
-                }
-            } catch (se: SecurityException) {
-                loge("SecurityException on bluetoothGatt.close() for $deviceAddress", se)
-            } finally {
-                bluetoothGatt.remove(deviceAddress)
-            }
-        }
-    }
-
-    /**
-     * Disconnect and cleanup all GATT connections.
-     */
-    fun disconnectAll() {
-        val addresses = bluetoothGatt.keys.toList()
-        addresses.forEach { disconnect(it) }
     }
 }

--- a/app/src/main/java/com/android/broadcastassistant/ble/BisSelectionManager.kt
+++ b/app/src/main/java/com/android/broadcastassistant/ble/BisSelectionManager.kt
@@ -11,12 +11,14 @@ import com.android.broadcastassistant.util.logw
 import com.android.broadcastassistant.util.logi
 
 /**
- * Manages BIS channel selection for Auracast devices.
+ * Manages BIS (Broadcast Isochronous Stream) channel selection for Auracast devices.
  *
  * Responsibilities:
- * - Selects one or multiple BIS indexes safely.
- * - Applies language-based fallback (single BIS per language).
- * - Sends 0x01 Select BIS for initial join or 0x03 Modify Source for already joined devices.
+ * - Safely select one or multiple BIS indexes for a device.
+ * - Apply language-based fallback (only one BIS per language is selected).
+ * - Send the appropriate BASS Control Point command:
+ *   - 0x01 Select BIS for initial join
+ *   - 0x03 Modify Source (Switch) for already joined devices
  */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 class BisSelectionManager(
@@ -24,33 +26,40 @@ class BisSelectionManager(
 ) {
 
     /**
-     * Selects BIS channels for a device.
+     * Selects BIS channels for a device and sends the corresponding Control Point command.
      *
      * @param device The target [AuracastDevice].
      * @param bisIndexes List of requested BIS indexes to select.
-     * @return [BisSelectionResult.Success] on success, or [BisSelectionResult.Failure] on error.
+     * @return [BisSelectionResult.Success] if selection succeeded, or [BisSelectionResult.Failure] if an error occurred.
      */
     suspend fun selectBisChannels(
         device: AuracastDevice,
         bisIndexes: List<Int>
     ): BisSelectionResult {
         try {
-            // Reject encrypted/private broadcasts
+            // Reject encrypted or private broadcasts (not supported)
             if (device.broadcastCode != null) {
                 val reason = "Encrypted/private broadcast not supported: ${device.address}"
                 logw(reason)
                 return BisSelectionResult.Failure(device, reason)
             }
 
-            // Filter selected BIS channels
-            val selectedChannels = device.bisChannels.filter { it.index in bisIndexes }
-            if (selectedChannels.isEmpty()) {
-                val reason = "BIS indexes $bisIndexes not found for ${device.address}"
+            // Ensure sourceId is available (populated by ScanDelegatorManager)
+            if (device.sourceId == null) {
+                val reason = "Missing sourceId for device ${device.address}. Ensure ScanDelegatorManager has provided it."
                 logw(reason)
                 return BisSelectionResult.Failure(device, reason)
             }
 
-            // Always fallback to single BIS per language
+            // Filter BIS channels that match requested indexes
+            val selectedChannels = device.bisChannels.filter { it.index in bisIndexes }
+            if (selectedChannels.isEmpty()) {
+                val reason = "Requested BIS indexes $bisIndexes not found for ${device.address}"
+                logw(reason)
+                return BisSelectionResult.Failure(device, reason)
+            }
+
+            // Apply language-based fallback: only one BIS per language
             val uniqueLanguages = mutableSetOf<String>()
             val channelsToSend = selectedChannels.filter { bis ->
                 val lang = bis.language.ifEmpty { "Unknown" }
@@ -61,52 +70,61 @@ class BisSelectionManager(
             }
 
             if (channelsToSend.isEmpty()) {
-                return BisSelectionResult.Failure(device, "No BIS channels available after fallback")
+                val reason = "No BIS channels available after language fallback for ${device.address}"
+                logw(reason)
+                return BisSelectionResult.Failure(device, reason)
             }
 
-            // Determine whether this is the first join
+            // Determine if this is the first join (Select BIS) or a modification (Switch)
             val firstJoin = device.selectedBisIndexes.isEmpty()
 
-            // Build Control Point command
-            val cpData = if (firstJoin) {
-                BassControlPointExtensions.buildSelectBisCommand(
-                    sourceId = device.sourceId
-                        ?: return BisSelectionResult.Failure(device, "Missing sourceId"),
-                    bisChannels = channelsToSend
-                )
-            } else {
-                BassControlPointBuilder.buildSwitchCommand(
-                    sourceId = device.sourceId
-                        ?: return BisSelectionResult.Failure(device, "Missing sourceId"),
-                    bisChannels = channelsToSend,
-                    broadcastId = device.broadcastId
-                        ?: return BisSelectionResult.Failure(device, "Missing broadcastId")
-                )
+            // Build the appropriate BASS Control Point command
+            val cpData = try {
+                if (firstJoin) {
+                    BassControlPointExtensions.buildSelectBisCommand(
+                        sourceId = device.sourceId!!,
+                        bisChannels = channelsToSend
+                    )
+                } else {
+                    BassControlPointBuilder.buildSwitchCommand(
+                        sourceId = device.sourceId!!,
+                        bisChannels = channelsToSend,
+                        broadcastId = device.broadcastId
+                            ?: return BisSelectionResult.Failure(device, "Missing broadcastId")
+                    )
+                }
+            } catch (e: Exception) {
+                loge("Failed to build Control Point command for ${device.address}", e)
+                return BisSelectionResult.Failure(device, "Failed to build Control Point command")
             }
 
+            // Create the BASS command object
             val command = BassCommand(
                 deviceAddress = device.address,
                 controlPointData = cpData,
                 autoDisconnect = false
             )
 
-            // Retry logic: attempt 2 times for transient BLE failures
+            // Retry sending the Control Point command up to 2 times
             repeat(2) { attempt ->
                 try {
                     bassGattManager.sendControlPoint(command)
-                    // Success: update device and return
+                    // Success: update device selected BIS indexes and return
                     device.selectedBisIndexes = channelsToSend.map { it.index }
-                    logi("BIS command succeeded for ${device.address}, indexes=${device.selectedBisIndexes}")
+                    logi("BIS command succeeded for ${device.address}, selected indexes=${device.selectedBisIndexes}")
                     return BisSelectionResult.Success(device, device.selectedBisIndexes)
                 } catch (e: Exception) {
                     logw("BIS command attempt ${attempt + 1} failed for ${device.address}", e)
                 }
             }
 
-            return BisSelectionResult.Failure(device, "Failed to send BIS command after retries")
+            // If all retries failed, return failure
+            val reason = "Failed to send BIS command after retries for ${device.address}"
+            loge(reason)
+            return BisSelectionResult.Failure(device, reason)
 
         } catch (e: Exception) {
-            loge("BIS selection failed for ${device.address}", e)
+            loge("Unexpected error during BIS selection for ${device.address}", e)
             return BisSelectionResult.Failure(device, e.message ?: "Unknown error")
         }
     }

--- a/app/src/main/java/com/android/broadcastassistant/data/AuracastDevice.kt
+++ b/app/src/main/java/com/android/broadcastassistant/data/AuracastDevice.kt
@@ -22,7 +22,7 @@ data class AuracastDevice(
     var selectedBisIndexes: List<Int> = emptyList(), // single or multi
     val broadcastId: Int? = null,
     val broadcastCode: ByteArray? = null,
-    val sourceId: Int? = null
+    var sourceId: Int? = null
 ) {
 
     /**

--- a/app/src/main/java/com/android/broadcastassistant/delegator/BassBroadcastStateParser.kt
+++ b/app/src/main/java/com/android/broadcastassistant/delegator/BassBroadcastStateParser.kt
@@ -1,0 +1,66 @@
+package com.android.broadcastassistant.delegator
+
+import com.android.broadcastassistant.util.*
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Parser for Broadcast Receive State (BRS) characteristic from a Scan Delegator.
+ *
+ * Responsibilities:
+ * - Parse the raw BRS byte array received over BLE.
+ * - Extract sourceId, broadcastId, and BIS synchronization bitmap.
+ * - Return structured [BassSourceInfo] list.
+ */
+object BassBroadcastStateParser {
+
+    /**
+     * Represents a Broadcast Source info from the BRS characteristic.
+     *
+     * @property sourceId The identifier of the broadcast source.
+     * @property broadcastId The 24-bit broadcast ID.
+     * @property bisSync List of active BIS indexes for this source.
+     */
+    data class BassSourceInfo(
+        val sourceId: Int,
+        val broadcastId: Int,
+        val bisSync: List<Int>
+    )
+
+    /**
+     * Parses a raw Broadcast Receive State byte array into a list of [BassSourceInfo].
+     *
+     * @param value Raw byte array from BRS characteristic.
+     * @return List of parsed [BassSourceInfo]. Returns empty list if parsing fails.
+     */
+    fun parse(value: ByteArray): List<BassSourceInfo> {
+        val sources = mutableListOf<BassSourceInfo>()
+
+        try {
+            val buf = ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN)
+
+            // Each entry requires at least 5 bytes: sourceId (1) + broadcastId (3) + BIS bitmap (1)
+            while (buf.remaining() >= 5) {
+                val sourceId = buf.get().toInt() and 0xFF // Source ID (1 byte)
+                val b0 = buf.get().toInt() and 0xFF       // Broadcast ID LSB
+                val b1 = buf.get().toInt() and 0xFF
+                val b2 = buf.get().toInt() and 0xFF       // Broadcast ID MSB
+
+                // Combine bytes into 24-bit broadcast ID (little-endian)
+                val broadcastId = (b2 shl 16) or (b1 shl 8) or b0
+
+                val bisBitmap = buf.get().toInt() and 0xFF // 8-bit bitmap of BIS
+                // Convert bitmap into list of active BIS indexes (1..8)
+                val bisList = (1..8).filter { (bisBitmap and (1 shl (it - 1))) != 0 }
+
+                sources.add(BassSourceInfo(sourceId, broadcastId, bisList))
+                logd("Parsed BroadcastReceiveState → sourceId=$sourceId, broadcastId=0x${broadcastId.toString(16)}, bis=$bisList")
+            }
+        } catch (e: Exception) {
+            // Log parsing error but continue; return whatever was parsed
+            loge("BassBroadcastStateParser: Failed to parse BRS characteristic", e)
+        }
+
+        return sources
+    }
+}

--- a/app/src/main/java/com/android/broadcastassistant/delegator/ScanDelegatorManager.kt
+++ b/app/src/main/java/com/android/broadcastassistant/delegator/ScanDelegatorManager.kt
@@ -1,0 +1,128 @@
+package com.android.broadcastassistant.delegator
+
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.*
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.ParcelUuid
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.MutableLiveData
+import com.android.broadcastassistant.util.*
+import com.android.broadcastassistant.util.UuidUtils
+import kotlinx.coroutines.*
+
+/**
+ * Manager for discovering Scan Delegators (BLE devices hosting the BASS service).
+ *
+ * Responsibilities:
+ * - Scan for nearby BLE devices advertising the BASS service.
+ * - Maintain a live list of discovered devices in [discoveredDelegators].
+ * - Start and stop BLE scanning safely with permission and error handling.
+ */
+@RequiresApi(Build.VERSION_CODES.S)
+class ScanDelegatorManager(private val context: Context) {
+
+    companion object {
+        // BASS service UUID filter for scanning
+        private val BASS_SERVICE_UUID: ParcelUuid = ParcelUuid(UuidUtils.BASS_SERVICE_UUID)
+    }
+
+    private val adapter by lazy {
+        (context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter
+    }
+
+    private val scanner by lazy { adapter.bluetoothLeScanner }
+
+    /** LiveData of discovered Scan Delegators */
+    val discoveredDelegators = MutableLiveData<List<BluetoothDevice>>(emptyList())
+
+    private var scanJob: Job? = null
+
+    /** Internal BLE scan callback */
+    private val callback = object : ScanCallback() {
+
+        override fun onScanResult(callbackType: Int, result: ScanResult) {
+            result.device?.let { device ->
+                logd("ScanDelegatorManager: Found Scan Delegator ${device.address}")
+
+                // Add new device if not already in the list
+                val current = discoveredDelegators.value?.toMutableList() ?: mutableListOf()
+                if (current.none { it.address == device.address }) {
+                    current.add(device)
+                    discoveredDelegators.postValue(current)
+                }
+            }
+        }
+
+        override fun onScanFailed(errorCode: Int) {
+            loge("ScanDelegatorManager: Scan failed with error code $errorCode")
+        }
+    }
+
+    /**
+     * Starts BLE scanning for Scan Delegators advertising the BASS service.
+     *
+     * Handles permission checks and logs errors on failure.
+     */
+    fun startScan() {
+        if (scanner == null) {
+            loge("ScanDelegatorManager: BluetoothLeScanner is null")
+            return
+        }
+
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            loge("ScanDelegatorManager: BLUETOOTH_SCAN permission not granted")
+            return
+        }
+
+        // Filter to only devices advertising the BASS service
+        val filter = ScanFilter.Builder()
+            .setServiceUuid(BASS_SERVICE_UUID)
+            .build()
+
+        val settings = ScanSettings.Builder()
+            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY) // aggressive scan for immediate results
+            .build()
+
+        scanJob = CoroutineScope(Dispatchers.IO).launch {
+            try {
+                scanner.startScan(listOf(filter), settings, callback)
+                logi("ScanDelegatorManager: Scan started for BASS service devices")
+            } catch (se: SecurityException) {
+                loge("ScanDelegatorManager: SecurityException during startScan", se)
+            } catch (e: Exception) {
+                loge("ScanDelegatorManager: Unexpected error during startScan", e)
+            }
+        }
+    }
+
+    /**
+     * Stops BLE scanning for Scan Delegators.
+     *
+     * Handles permission checks and safely cancels ongoing scan coroutine.
+     */
+    fun stopScan() {
+        try {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN)
+                == PackageManager.PERMISSION_GRANTED
+            ) {
+                scanner?.stopScan(callback)
+                scanJob?.cancel()
+                scanJob = null
+                logi("ScanDelegatorManager: Scan stopped")
+            } else {
+                logw("ScanDelegatorManager: BLUETOOTH_SCAN permission not granted, cannot stop scan")
+            }
+        } catch (se: SecurityException) {
+            loge("ScanDelegatorManager: SecurityException while stopping scan", se)
+        } catch (e: Exception) {
+            loge("ScanDelegatorManager: Unexpected error while stopping scan", e)
+        }
+    }
+}

--- a/app/src/main/java/com/android/broadcastassistant/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/android/broadcastassistant/ui/navigation/AppNavHost.kt
@@ -11,56 +11,69 @@ import com.android.broadcastassistant.ui.screen.auracast.AuracastScreen
 import com.android.broadcastassistant.ui.screen.bisselection.BisChannelScreen
 import com.android.broadcastassistant.data.AuracastDevice
 import com.android.broadcastassistant.util.loge
+import com.android.broadcastassistant.util.logi
 import com.android.broadcastassistant.viewmodel.AuracastViewModel
 
 /**
- * The main navigation host for the Auracast app.
+ * Main navigation host for the Auracast app.
  *
  * Responsibilities:
- * - Displays the Auracast device list ([AuracastScreen]) as the start destination.
- * - Navigates to BIS selection screen ([BisChannelScreen]) for a selected device.
- * - Observes state from [AuracastViewModel] including devices, scanning status, permissions, and status messages.
- *
- * @param viewModel The [AuracastViewModel] providing state for devices and scanning.
+ * - Display list of Auracast devices (broadcasters and receivers) on [AuracastScreen].
+ * - Navigate to BIS selection screen ([BisChannelScreen]) for selected broadcasters.
+ * - Observe state from [AuracastViewModel] for devices, scanning status, permissions, and status messages.
  */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 fun AppNavHost(viewModel: AuracastViewModel = viewModel()) {
     val navController = rememberNavController()
 
+    // Collect state from ViewModel
     val devices by viewModel.devices.collectAsState(initial = emptyList())
     val isScanning by viewModel.isScanning.collectAsState(initial = false)
     val permissionsGranted by viewModel.permissionsGranted.collectAsState(initial = false)
     val statusMessage by viewModel.statusMessage.collectAsState(initial = "")
 
+    // Split devices into broadcasters (have broadcastId) and receivers (no broadcastId)
+    val broadcasters = devices.filter { it.broadcastId != null }
+    val receivers = devices.filter { it.broadcastId == null }
+
     NavHost(navController = navController, startDestination = "auracast") {
 
-        // Main Auracast device list
+        // Main Auracast device list screen
         composable("auracast") {
             AuracastScreen(
-                devices = devices,
+                broadcasters = broadcasters,
+                receivers = receivers,
                 isScanning = isScanning,
                 permissionsGranted = permissionsGranted,
                 statusMessage = statusMessage,
                 onToggleScan = { viewModel.toggleScan() },
                 onDeviceClick = { device ->
-                    navController.navigate("bis/${device.address}")
+                    // Navigate to BIS selection screen only for broadcasters
+                    if (device.broadcastId != null) {
+                        navController.navigate("bis/${device.address}")
+                    } else {
+                        // Optional: handle receiver click (e.g., show info toast or log)
+                        logi("Clicked receiver device: ${device.address}")
+                    }
                 }
             )
         }
 
-        // BIS Channel Screen for a selected device
+        // BIS Channel Screen for a selected broadcaster device
         composable(
             "bis/{deviceAddress}",
             arguments = listOf(navArgument("deviceAddress") { type = NavType.StringType })
         ) { backStackEntry ->
             val address = backStackEntry.arguments?.getString("deviceAddress")
+
+            // Find device from current ViewModel state
             val device: AuracastDevice? = devices.find { it.address == address }
 
             device?.let {
                 BisChannelScreen(
                     device = it,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStack() } // Navigate back to AuracastScreen
                 )
             } ?: run {
                 loge("AppNavHost: Device not found for address=$address")

--- a/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastDeviceCard.kt
+++ b/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastDeviceCard.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.*
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -13,10 +13,14 @@ import androidx.compose.ui.text.font.FontWeight
 import com.android.broadcastassistant.data.AuracastDevice
 
 /**
- * Displays a card representing an Auracast broadcaster device.
+ * Displays a card representing an Auracast device (broadcaster or receiver).
  *
- * Shows device name, address, RSSI, optional broadcast ID, and any selected BIS indexes.
- * Highlights the card if [isSelected] is true.
+ * Features:
+ * - Shows device name, address, and RSSI.
+ * - Shows broadcast ID if the device is a broadcaster.
+ * - Shows selected BIS indexes if available.
+ * - Highlights the card if [isSelected] is true.
+ * - Differentiates broadcasters (blue) and receivers (green).
  *
  * @param device The [AuracastDevice] to display.
  * @param isSelected Whether this device is currently selected (affects card color).
@@ -28,19 +32,23 @@ fun AuracastDeviceCard(
     isSelected: Boolean = false,
     onClick: () -> Unit
 ) {
-    // Card container with padding, click behavior, and color based on selection
+    // Determine card background color based on selection and device type
+    val containerColor = when {
+        isSelected -> Color(0xFF1976D2)                 // Highlight selected device
+        device.broadcastId == null -> Color(0xFF43A047) // Receiver (green)
+        else -> Color(0xFF1A73E8)                       // Broadcaster (blue)
+    }
+
     Card(
         modifier = Modifier
-            .fillMaxWidth() // Make card stretch full width
-            .padding(vertical = 8.dp) // Vertical spacing between cards
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
             .clickable { onClick() }, // Handle click events
-        colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) Color(0xFF1976D2) else Color(0xFF1A73E8) // Highlight selected card
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp) // Card shadow
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            // Display device name and address
+            // Device name and address (bold)
             Text(
                 text = "${device.name} (${device.address})",
                 fontWeight = FontWeight.Bold,
@@ -48,36 +56,42 @@ fun AuracastDeviceCard(
                 color = Color.White
             )
 
-            // Display device RSSI
+            // RSSI display
             Text(
                 text = "RSSI: ${device.rssi} dBm",
                 fontSize = 14.sp,
                 color = Color.White
             )
 
-            // Display optional Broadcast ID if available
-            device.broadcastId?.let {
+            // Show broadcast ID for broadcasters
+            device.broadcastId?.let { broadcastId ->
                 Text(
-                    text = "Broadcast ID: $it",
+                    text = "Broadcast ID: $broadcastId",
                     fontSize = 14.sp,
                     color = Color.White
                 )
             }
 
-            // Overlay for selected BIS channels
+            // Label receivers
+            if (device.broadcastId == null) {
+                Text(
+                    text = "Receiver",
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = Color.White,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
+            // Overlay displaying selected BIS channels
             if (device.selectedBisIndexes.isNotEmpty()) {
                 Row(
                     modifier = Modifier
-                        .padding(top = 6.dp) // Top spacing from previous Text
-                        .background(Color(0x33000000)) // Semi-transparent background
-                        .padding(horizontal = 6.dp, vertical = 2.dp) // Inner padding
+                        .padding(top = 6.dp)
+                        .background(Color(0x33000000)) // Semi-transparent overlay
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
                 ) {
-                    Text(
-                        text = "Selected BIS: ",
-                        color = Color.Yellow,
-                        fontSize = 12.sp
-                    )
-                    // Display each selected BIS index
+                    Text("Selected BIS: ", color = Color.Yellow, fontSize = 12.sp)
                     device.selectedBisIndexes.forEach { index ->
                         Text("$index ", color = Color.Green, fontSize = 12.sp)
                     }

--- a/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastDeviceList.kt
+++ b/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastDeviceList.kt
@@ -14,17 +14,21 @@ import com.android.broadcastassistant.data.AuracastDevice
 import com.android.broadcastassistant.ui.theme.AppTextPrimary
 
 /**
- * Displays a scrollable list of Auracast devices.
+ * Displays a scrollable list of Auracast devices (broadcasters and receivers).
  *
- * Handles permission checks, status messages, and highlights the currently selected device.
+ * Features:
+ * - Shows status messages above the list.
+ * - Handles permission warnings if Bluetooth scan/connect permissions are missing.
+ * - Highlights the currently selected device.
+ * - Only allows clicks on broadcasters (devices with broadcastId).
  *
  * @param devices List of [AuracastDevice]s to display.
- * @param permissionsGranted Whether Bluetooth permissions are granted.
+ * @param permissionsGranted Whether required Bluetooth permissions are granted.
  * @param statusMessage Optional status message to show above the list.
- * @param onDeviceClick Callback invoked when a device is clicked.
+ * @param onDeviceClick Callback invoked when a broadcaster device is clicked.
  * @param modifier Optional [Modifier] for the outer container.
- * @param listState [LazyListState] for scrolling control.
- * @param selectedDeviceAddress Address of the currently selected device for highlighting.
+ * @param listState [LazyListState] for scroll control.
+ * @param selectedDeviceAddress Address of the currently selected device (for highlighting).
  */
 @Composable
 fun AuracastDeviceList(
@@ -34,15 +38,14 @@ fun AuracastDeviceList(
     onDeviceClick: (AuracastDevice) -> Unit,
     modifier: Modifier = Modifier,
     listState: LazyListState,
-    selectedDeviceAddress: String? = null // highlight selected device
+    selectedDeviceAddress: String? = null
 ) {
-    // Column container with padding and full size
     Column(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        // Show status message if provided
+        // Show status message if available
         if (statusMessage.isNotBlank()) {
             Text(
                 text = statusMessage,
@@ -51,31 +54,49 @@ fun AuracastDeviceList(
             )
         }
 
-        // Show permissions warning if Bluetooth permissions not granted
+        // Show permission warning and prevent further UI if not granted
         if (!permissionsGranted) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                Text("Bluetooth permissions are required.", color = Color.Red)
+                Text(
+                    text = "Bluetooth permissions are required.",
+                    color = Color.Red
+                )
             }
-            return@Column // Exit early if permissions are missing
+            return@Column // Stop further rendering if permissions missing
         }
 
-        // Show device list if devices are available
+        // Show device list if available
         if (devices.isNotEmpty()) {
             LazyColumn(state = listState) {
                 items(devices) { device ->
-                    // Determine if this device is currently selected
                     val isSelected = device.address == selectedDeviceAddress
 
-                    // Display individual device card
+                    // AuracastDeviceCard handles broadcaster/receiver styling
                     AuracastDeviceCard(
                         device = device,
-                        isSelected = isSelected, // highlight selected device
-                        onClick = { onDeviceClick(device) }
+                        isSelected = isSelected,
+                        onClick = {
+                            // Only allow clicks for broadcasters
+                            if (device.broadcastId != null) {
+                                onDeviceClick(device)
+                            }
+                        }
                     )
                 }
+            }
+        } else {
+            // Show fallback text if no devices found
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "No devices found",
+                    color = AppTextPrimary
+                )
             }
         }
     }

--- a/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastScreen.kt
+++ b/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastScreen.kt
@@ -13,36 +13,41 @@ import androidx.compose.ui.unit.sp
 import com.android.broadcastassistant.data.AuracastDevice
 
 /**
- * Main screen displaying Auracast broadcasters.
+ * Main screen displaying Auracast broadcasters and receivers.
  *
- * Shows a top app bar with scan toggle button, a list of devices,
- * highlights the selected device, and handles permission & status messages.
+ * Features:
+ * - Top App Bar with app title and scan toggle button.
+ * - Shows merged list of broadcasters and receivers.
+ * - Highlights the currently selected device.
+ * - Handles permission and status messages.
+ * - Restricts clicks for receivers (no BIS channels).
  *
- * @param devices List of [AuracastDevice]s discovered or mocked for UI.
+ * @param broadcasters List of broadcaster [AuracastDevice]s discovered or mocked.
+ * @param receivers List of receiver [AuracastDevice]s discovered via Scan Delegators.
  * @param isScanning Whether BLE scanning is currently active.
  * @param permissionsGranted Whether Bluetooth permissions are granted.
- * @param statusMessage Optional status message to display above the list.
+ * @param statusMessage Optional status message displayed above the list.
  * @param onToggleScan Callback to start/stop scanning.
- * @param onDeviceClick Callback when a device is clicked.
+ * @param onDeviceClick Callback invoked when a broadcaster device is clicked.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AuracastScreen(
-    devices: List<AuracastDevice>,
+    broadcasters: List<AuracastDevice>,
+    receivers: List<AuracastDevice>,
     isScanning: Boolean,
     permissionsGranted: Boolean,
     statusMessage: String,
     onToggleScan: () -> Unit,
     onDeviceClick: (AuracastDevice) -> Unit
 ) {
-    // Remember scroll state for LazyColumn
-    val listState = rememberLazyListState()
+    val listState = rememberLazyListState() // For controlling scrolling
+    var selectedDeviceAddress by remember { mutableStateOf<String?>(null) } // Track selected device
 
-    // Track the currently selected device by its address
-    var selectedDeviceAddress by remember { mutableStateOf<String?>(null) }
+    // Merge broadcasters and receivers for display
+    val allDevices = broadcasters + receivers
 
     Scaffold(
-        // Top app bar with title and scan toggle button
         topBar = {
             TopAppBar(
                 title = {
@@ -54,8 +59,9 @@ fun AuracastScreen(
                     )
                 },
                 actions = {
+                    // Scan toggle button
                     Button(
-                        onClick = onToggleScan, // Trigger scan toggle
+                        onClick = onToggleScan,
                         colors = ButtonDefaults.buttonColors(
                             containerColor = if (isScanning) Color(0xFF0D47A1) else Color(0xFF1976D2),
                             contentColor = Color.White
@@ -76,20 +82,24 @@ fun AuracastScreen(
         },
         containerColor = Color.White
     ) { padding ->
-        // Display the list of Auracast devices
+        // Display merged list of broadcasters and receivers
         AuracastDeviceList(
-            devices = devices,
+            devices = allDevices,
             permissionsGranted = permissionsGranted,
             statusMessage = statusMessage,
             onDeviceClick = { device ->
-                selectedDeviceAddress = device.address // update selected device
-                onDeviceClick(device) // propagate click event
+                selectedDeviceAddress = device.address // Highlight selected device
+
+                // Only navigate/call callback if the device is a broadcaster
+                if (device.broadcastId != null) {
+                    onDeviceClick(device)
+                }
             },
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding), // respect Scaffold padding
+                .padding(padding),
             listState = listState,
-            selectedDeviceAddress = selectedDeviceAddress // highlight selected device
+            selectedDeviceAddress = selectedDeviceAddress
         )
     }
 }

--- a/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastScreenPreview.kt
+++ b/app/src/main/java/com/android/broadcastassistant/ui/screen/auracast/AuracastScreenPreview.kt
@@ -13,25 +13,44 @@ import com.android.broadcastassistant.data.AuracastDevice
  * - Permissions granted
  * - Status message display
  * - Selected BIS highlighting for alternate devices
+ * - Broadcasters vs Receivers differentiation
  */
 @Composable
 @Preview(showBackground = true, apiLevel = 34)
 fun AuracastScreenPreview() {
-    // Generate dummy devices from preview helper
-    val dummyDevices: List<AuracastDevice> = PreviewAuracastDevice.fakeBroadcasters().mapIndexed { index, device ->
-        // Mark every other device with selected BIS indices for demonstration
+    // Generate dummy broadcasters
+    val broadcasterDevices: List<AuracastDevice> = PreviewAuracastDevice.fakeBroadcasters().mapIndexed { index, device ->
         device.copy(
             selectedBisIndexes = if (index % 2 == 0) listOf(1, 2) else emptyList()
         )
     }
 
-    // Display AuracastScreen with preview parameters
+    // Generate dummy receivers manually (broadcastId = null)
+    val receiverDevices: List<AuracastDevice> = List(3) { index ->
+        AuracastDevice(
+            name = "Receiver $index",
+            address = "00:11:22:33:44:${index}5",
+            rssi = -50 + index,
+            broadcastId = null, // null = receiver
+            selectedBisIndexes = if (index % 2 != 0) listOf(1) else emptyList()
+        )
+    }
+
+    // Display AuracastScreen with separate broadcasters and receivers
     AuracastScreen(
-        devices = dummyDevices,
-        isScanning = true, // simulate scanning state
-        permissionsGranted = true, // simulate permissions granted
-        statusMessage = "Scanning – ${dummyDevices.size} devices found", // show status message
-        onToggleScan = {}, // no-op for preview
-        onDeviceClick = {} // no-op for preview
+        broadcasters = broadcasterDevices,
+        receivers = receiverDevices,
+        isScanning = true,
+        permissionsGranted = true,
+        statusMessage = "Scanning – ${broadcasterDevices.size + receiverDevices.size} devices found",
+        onToggleScan = {},
+        onDeviceClick = { device ->
+            // Only simulate navigation for broadcasters in preview
+            if (device.broadcastId != null) {
+                println("Broadcaster clicked: ${device.name} – navigate to BIS selection")
+            } else {
+                println("Receiver clicked: ${device.name} – no BIS selection")
+            }
+        }
     )
 }

--- a/app/src/main/java/com/android/broadcastassistant/util/UuidUtils.kt
+++ b/app/src/main/java/com/android/broadcastassistant/util/UuidUtils.kt
@@ -20,8 +20,11 @@ object UuidUtils {
     /** Broadcast Audio Scan Service (BASS) UUID (16-bit: 0x184F). */
     val BASS_SERVICE_UUID: UUID = from16Bit(0x184F)
 
-    /** BASS Control Point Characteristic UUID (16-bit: 0x2B2B). */
-    val BASS_CONTROL_POINT_UUID: UUID = from16Bit(0x2B2B)
+    /** BASS Control Point Characteristic UUID (16-bit: 0x2BBA). */
+    val BASS_CONTROL_POINT_UUID: UUID = from16Bit(0x2BBA)
+
+    /** BASS Broadcast Receive State Characteristic UUID (16-bit: 0x2BC9). */
+    val BASS_BROADCAST_RECEIVE_STATE_UUID: UUID = from16Bit(0x2BC9)
 
     /**
      * Convert a 16-bit Bluetooth UUID into a full 128-bit [UUID].

--- a/app/src/main/java/com/android/broadcastassistant/viewmodel/AuracastViewModel.kt
+++ b/app/src/main/java/com/android/broadcastassistant/viewmodel/AuracastViewModel.kt
@@ -15,10 +15,12 @@ import com.android.broadcastassistant.ble.AuracastEaScanner
 import com.android.broadcastassistant.ble.BisSelectionManager
 import com.android.broadcastassistant.data.AuracastDevice
 import com.android.broadcastassistant.data.BisSelectionResult
+import com.android.broadcastassistant.delegator.ScanDelegatorManager
 import com.android.broadcastassistant.util.logd
 import com.android.broadcastassistant.util.logi
-import com.android.broadcastassistant.util.logw
 import com.android.broadcastassistant.util.loge
+import com.android.broadcastassistant.util.logw
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -29,18 +31,18 @@ private val Application.dataStore by preferencesDataStore(name = "auracast_prefs
 private val SELECTED_BIS_KEY = intPreferencesKey("selected_bis_index")
 
 /**
- * ViewModel for Auracast scanning, device list, and BIS selection.
+ * ViewModel for managing Auracast BLE devices and BIS channel selection.
  *
- * Handles:
- * - Device scanning via [AuracastEaScanner]
- * - BIS selection via [BisSelectionManager]
- * - State updates for UI
- * - Persists first selected BIS index for highlight
+ * Responsibilities:
+ * - Scans for Auracast broadcasters and Scan Delegators
+ * - Maintains device list, scan status, and UI state
+ * - Handles BIS channel selection using [BisSelectionManager]
+ * - Persists selected BIS index in DataStore
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 class AuracastViewModel(application: Application) : AndroidViewModel(application) {
 
-    // State flows exposed to the UI
     private val _devices = MutableStateFlow<List<AuracastDevice>>(emptyList())
     val devices: StateFlow<List<AuracastDevice>> = _devices
 
@@ -54,12 +56,20 @@ class AuracastViewModel(application: Application) : AndroidViewModel(application
 
     private val bassGattManager = BassGattManager(getApplication<Application>().applicationContext)
     private val bisSelectionManager = BisSelectionManager(bassGattManager)
+    private val scanDelegatorManager = ScanDelegatorManager(getApplication<Application>().applicationContext)
     private val scanner = AuracastEaScanner(getApplication<Application>().applicationContext)
 
     private val _permissionsGranted = MutableStateFlow(false)
     val permissionsGranted: StateFlow<Boolean> = _permissionsGranted
 
     init {
+        // Observe discovered Scan Delegators for logging
+        viewModelScope.launch {
+            scanDelegatorManager.discoveredDelegators.observeForever { delegators ->
+                logd("Discovered ${delegators.size} Scan Delegators")
+            }
+        }
+
         // Initialize scanner and restore saved BIS selection
         viewModelScope.launch {
             try {
@@ -82,42 +92,44 @@ class AuracastViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    /** Update Bluetooth permissions state and stop scan if revoked */
+    /**
+     * Update Bluetooth permission state.
+     *
+     * @param granted true if permissions are granted, false otherwise.
+     */
     fun updatePermissionsGranted(granted: Boolean) {
         logi("Bluetooth permissions updated: $granted")
         _permissionsGranted.value = granted
-        if (!granted) {
-            logw("Permissions revoked, stopping scan")
-            stopScan()
-        }
+        if (!granted) stopScan() // Stop scanning if permissions are revoked
     }
 
-    /** Start Auracast scanning */
+    /**
+     * Start scanning for Auracast broadcasters and Scan Delegators.
+     *
+     * Clears previous scan results, updates UI state, and logs events.
+     */
     fun startScan() {
-        if (!_permissionsGranted.value) {
-            logw("Cannot start scan: permissions not granted")
-            return
-        }
-        if (_isScanning.value) {
-            logw("Scan already running")
-            return
-        }
+        if (!_permissionsGranted.value) return
+        if (_isScanning.value) return
 
         logi("Starting Auracast scan")
-        _devices.value = emptyList() // clear current devices
-        scanner.clearDevices()
+        _devices.value = emptyList()
+        scanner.clearDevices() // Clear previous scan results
         scanner.startScanningAuracastEa()
         _isScanning.value = true
         _statusMessage.value = getApplication<Application>().getString(R.string.scan_starting)
         _statusColor.value = Color.Blue
+
+        scanDelegatorManager.startScan() // Start Scan Delegator discovery
     }
 
-    /** Stop Auracast scanning */
+    /**
+     * Stop scanning for Auracast broadcasters and Scan Delegators.
+     *
+     * Updates scan state, status message, and logs events.
+     */
     fun stopScan() {
-        if (!_isScanning.value) {
-            logw("Stop scan called but scan not running")
-            return
-        }
+        if (!_isScanning.value) return
 
         logi("Stopping Auracast scan")
         scanner.stopScanningAuracastEa()
@@ -126,74 +138,111 @@ class AuracastViewModel(application: Application) : AndroidViewModel(application
             R.string.scan_stopped, _devices.value.size
         )
         _statusColor.value = Color.Black
+
+        scanDelegatorManager.stopScan() // Stop delegator scan
     }
 
-    /** Toggle scanning state */
+    /**
+     * Toggle scanning state (start or stop scan).
+     */
     fun toggleScan() {
-        logd("Toggling scan. Current state: ${_isScanning.value}")
         if (_isScanning.value) stopScan() else startScan()
     }
 
     /**
-     * Safely select BIS channels for a device.
-     * - Updates device state and UI
-     * - Persists first selected BIS index
-     * - Handles success and failure messages
+     * Select BIS channels for a device safely.
+     *
+     * Steps:
+     * 1. Pick first available Scan Delegator.
+     * 2. Read Broadcast Receive State from delegator.
+     * 3. Match device broadcastId to sourceId.
+     * 4. Use [BisSelectionManager] to send BIS select/modify command.
+     * 5. Update state and persist selected BIS index.
+     *
+     * @param device Target Auracast device.
+     * @param bisIndexes List of requested BIS indexes.
      */
     fun selectBisChannels(device: AuracastDevice, bisIndexes: List<Int>) {
-        if (bisIndexes.isEmpty()) {
-            logw("selectBisChannels called with empty list")
-            return
-        }
+        if (bisIndexes.isEmpty()) return
 
         viewModelScope.launch {
-            logi("Selecting BIS indexes ${bisIndexes.joinToString()} for device ${device.address}")
             _statusMessage.value = getApplication<Application>().getString(
                 R.string.switching_language, bisIndexes.joinToString(", ")
             )
             _statusColor.value = Color.Yellow
 
             try {
+                // Pick first available Scan Delegator
+                val delegator = scanDelegatorManager.discoveredDelegators.value?.firstOrNull()
+                if (delegator == null) {
+                    _statusMessage.value = "No Scan Delegator available"
+                    _statusColor.value = Color.Red
+                    logw("No Scan Delegator found for BIS selection")
+                    return@launch
+                }
+
+                // Read Broadcast Receive State characteristic
+                val sources = bassGattManager.readBroadcastReceiveState(delegator.address)
+                val match = sources.find { it.broadcastId == device.broadcastId }
+                if (match == null) {
+                    _statusMessage.value = "No matching broadcast on delegator"
+                    _statusColor.value = Color.Red
+                    logw("No matching broadcast for device ${device.address} on delegator ${delegator.address}")
+                    return@launch
+                }
+
+                // Update device with sourceId
+                device.sourceId = match.sourceId
+
+                // Use BisSelectionManager to send BIS command
                 val result = bisSelectionManager.selectBisChannels(device, bisIndexes)
                 when (result) {
                     is BisSelectionResult.Success -> {
-                        logi("BIS selection succeeded: ${result.selectedIndexes.joinToString()}")
                         val indexesStr = result.selectedIndexes.joinToString(", ")
                         _statusMessage.value = getApplication<Application>().getString(
                             R.string.connected_language, indexesStr
                         )
                         _statusColor.value = Color.Green
+                        logi("BIS selection successful for ${device.address}: $indexesStr")
 
+                        // Update devices list state
                         _devices.value = _devices.value.map { d ->
                             if (d.address == device.address) d.copy(selectedBisIndexes = result.selectedIndexes)
                             else d
                         }
 
+                        // Persist first selected BIS index
                         getApplication<Application>().dataStore.edit { prefs ->
                             prefs[SELECTED_BIS_KEY] = result.selectedIndexes.first()
                         }
                     }
                     is BisSelectionResult.Failure -> {
-                        logw("BIS selection failed: ${result.reason}")
                         _statusMessage.value = "BIS switch failed: ${result.reason}"
                         _statusColor.value = Color.Red
+                        logw("BIS selection failed for ${device.address}: ${result.reason}")
                     }
                 }
+
             } catch (e: Exception) {
-                loge("Exception during BIS selection", e)
                 _statusMessage.value = "BIS switch failed: ${e.message}"
                 _statusColor.value = Color.Red
+                loge("Exception during BIS selection for ${device.address}", e)
             }
         }
     }
 
-    /** Cleanup resources when ViewModel is destroyed */
+    /**
+     * Clean up resources when ViewModel is cleared.
+     *
+     * Stops scanning, disconnects devices, and logs cleanup.
+     */
     override fun onCleared() {
         super.onCleared()
         try {
-            logi("ViewModel clearing: stopping scanner and disconnecting GATT")
             scanner.stopScanningAuracastEa()
             bassGattManager.disconnectAll()
+            scanDelegatorManager.stopScan()
+            logi("AuracastViewModel cleared successfully")
         } catch (e: Exception) {
             loge("Error during ViewModel cleared", e)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,19 @@
 [versions]
-agp = "8.12.2"
-kotlin = "2.2.10"
+agp = "8.12.3"
+kotlin = "2.2.20"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.3"
-activityCompose = "1.10.1"
-composeBom = "2025.08.01"
+activityCompose = "1.11.0"
+composeBom = "2025.09.00"
 appcompat = "1.7.1"
-navigationCompose = "2.9.3"
-uiVersion = "1.9.0"
-navigationRuntimeAndroid = "2.9.3"
-uiText = "1.9.0"
+navigationCompose = "2.9.4"
+uiVersion = "1.9.1"
+navigationRuntimeAndroid = "2.9.4"
+uiText = "1.9.1"
+roomKtx = "2.8.0"
 
 [libraries]
 androidx-compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "uiVersion" }
@@ -31,12 +32,13 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version = "1.9.0" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version = "1.9.1" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
 androidx-ui-text = { group = "androidx.compose.ui", name = "ui-text", version.ref = "uiText" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "roomKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION

Implemented receiver device handling via Scan Delegators, displaying them in the device list with distinct green cards showing RSSI, name, and address. Receivers do not navigate to BIS selection screens, and selection highlighting reflects the active receiver.